### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ With diversified devices and industries, Tuya IoT Development Platform opens bas
 
 ## Release Note
 
-| version | Description             |
-|---------|-------------------------|
-| 0.1.8   | fix topic error         |
-| 0.1.9   | fix mq link id          |
-| 0.2.0   | MQTT bulk subscription  |
+| version | Description                                            |
+| ------- | ------------------------------------------------------ |
+| 0.1.8   | fix topic error                                        |
+| 0.1.9   | fix mq link id                                         |
+| 0.2.0   | MQTT bulk subscription                                 |
+| 0.2.1   | add updated_status_properties to SharingDeviceListener |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ With diversified devices and industries, Tuya IoT Development Platform opens bas
 
 ## Release Note
 
-| version | Description       |
-|---------|-------------------|
-| 0.1.8   | fix topic error   |
-| 0.1.9   | fix mq link id    |
+| version | Description             |
+|---------|-------------------------|
+| 0.1.8   | fix topic error         |
+| 0.1.9   | fix mq link id          |
+| 0.2.0   | MQTT bulk subscription  |
 
 ## Installation
 

--- a/tuya_sharing/mq.py
+++ b/tuya_sharing/mq.py
@@ -119,12 +119,12 @@ class SharingMQ(threading.Thread):
                 backoff_seconds = 1
 
                 # reconnect every 2 hours required.
-                time.sleep(self.mq_config.expire_time - 60)
+                self._stop_event.wait(self.mq_config.expire_time - 60)
             except RequestException as e:
                 logger.exception(e)
                 logger.error(f"failed to refresh mqtt server, retrying in {backoff_seconds} seconds.")
 
-                time.sleep(backoff_seconds)
+                self._stop_event.wait(backoff_seconds)
                 backoff_seconds = min(backoff_seconds * 2, 60)  # Try at most every 60 seconds to refresh
 
     def __run_mqtt(self):

--- a/tuya_sharing/version.py
+++ b/tuya_sharing/version.py
@@ -1,3 +1,3 @@
 """smartlife device sharing sdk version."""
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"

--- a/tuya_sharing/version.py
+++ b/tuya_sharing/version.py
@@ -1,3 +1,3 @@
 """smartlife device sharing sdk version."""
 
-VERSION = "0.1.9"
+VERSION = "0.2.0"


### PR DESCRIPTION
SharingMQ.run():
use Event.wait() instead of time.sleep() such that setting the flag also
	stops the sleep;
there is no way to stop time.sleep() in a secondary thread and waiting
	two hours for _stop_event to take effect is too long;